### PR TITLE
FIXES #40: Corregir error en línea 118 de colores.html

### DIFF
--- a/html_meroh/colores.html
+++ b/html_meroh/colores.html
@@ -115,8 +115,9 @@
         <input type="text" id="nombreInput" placeholder="Tu nombre">
         <button id="guardarNombre">Guardar Tu Nombre Completo</button>
 
-        <h2>Tu Nombre:</h2>
-        <h2 id="Nombre que se muestra"></h2>
+        
+        <h2 id="nombreMostrado">Tu Nombre:</h2>
+
     </div>
 
     <script>


### PR DESCRIPTION
-Se corrigió el error que provocaba el mensaje "Uncaught TypeError: Cannot set properties of null (setting 'textContent')" en la línea 118 de colores.html.
- Se aseguró de que el código funcione correctamente y que el nombre del usuario se muestre adecuadamente en la página.